### PR TITLE
Fix EMR is not valid for managed_scaling_policy

### DIFF
--- a/internal/service/emr/managed_scaling_policy.go
+++ b/internal/service/emr/managed_scaling_policy.go
@@ -115,6 +115,12 @@ func resourceManagedScalingPolicyRead(d *schema.ResourceData, meta interface{}) 
 		d.SetId("")
 		return nil
 	}
+	
+	if tfawserr.ErrMessageContains(err, "ValidationException", "is not valid") {
+		log.Printf("[WARN] EMR Cluster (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if tfawserr.ErrMessageContains(err, "InvalidRequestException", "does not exist") {
 		log.Printf("[WARN] EMR Managed Scaling Policy (%s) not found, removing from state", d.Id())
@@ -152,7 +158,13 @@ func resourceManagedScalingPolicyDelete(d *schema.ResourceData, meta interface{}
 	if tfawserr.ErrMessageContains(err, "ValidationException", "A job flow that is shutting down, terminated, or finished may not be modified") {
 		return nil
 	}
-
+	
+	if tfawserr.ErrMessageContains(err, "ValidationException", "is not valid") {
+		log.Printf("[WARN] EMR Cluster (%s) not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+	
 	if tfawserr.ErrMessageContains(err, "InvalidRequestException", "does not exist") {
 		return nil
 	}


### PR DESCRIPTION
Fix aws_emr_managed_scaling_policy for compatibility with the behavior of emr_cluster that was fixed as a part of the next problem:

https://github.com/hashicorp/terraform-provider-aws/pull/16924
https://github.com/hashicorp/terraform-provider-aws/issues/7783

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
